### PR TITLE
Define separate Dockerfiles for Postgres and Make services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # Data
 db/raw/*.osm
 db/import/*.table
+db/import/*.fixture

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential gcc make cmake gdal-bin postgresql-server-dev-11 postgresql-11-postgis-2.5 \
+    expat libexpat1-dev libboost-dev libboost-graph-dev libboost-program-options-dev libpqxx-dev \
+    wget ca-certificates
+
+RUN wget -O pgrouting-3.1.0.tar.gz https://github.com/pgRouting/pgrouting/archive/v3.1.0.tar.gz && \
+    tar xvfz pgrouting-3.1.0.tar.gz && \
+    cd pgrouting-3.1.0 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install && \
+    cd / && rm -Rf pgrouting-3.1.0*
+
+RUN wget -O osm2pgrouting-2.3.6.tar.gz https://github.com/pgRouting/osm2pgrouting/archive/v2.3.6.tar.gz && \
+    tar xvfz osm2pgrouting-2.3.6.tar.gz && \
+    cd osm2pgrouting-2.3.6 && \
+    cmake -H. -Bbuild && \
+    cd build && \
+    make && \
+    make install && \
+    cd / && rm -Rf osm2pgrouting-2.3.6*
+
+COPY ./app/requirements.txt /app/requirements.txt
+RUN pip3 install --no-cache-dir -r /app/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: all
-all: db/import/mellowroute.table db/import/chicago.table
+all: db/import/mellowroute.fixture db/import/chicago.table
 
-db/import/mellowroute.table: app/mbm/fixtures/mellowroute.json
-	python manage.py loaddata $< && touch $@
+db/import/%.fixture: app/mbm/fixtures/%.json
+	(cd app && python manage.py loaddata $*) && touch $@
 
 db/import/chicago.table: db/raw/chicago.osm
 	osm2pgrouting -f $< -c /usr/local/share/osm2pgrouting/mapconfig_for_bicycles.xml --prefix chicago_ --addnodes --tags --clean \

--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@ Development requires Docker and Docker Compose.
 Build containers:
 
 ```
-docker-compose build
+docker-compose -f docker-compose.yml -f docker-compose.db.yml build
 ```
 
-Import the data:
+Run migrations:
 
 ```
-docker-compose -f docker-compose.yml -f db/docker-compose.yml run --rm make
+docker-compose run --rm app ./manage.py migrate
+```
+
+Import the data (note that the full data import can take quite a bit of memory,
+so make sure to adjust your Docker preferences to allow Docker at least 6GB of
+RAM):
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.db.yml run --rm make
 ```
 
 Start the app service:

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -2,7 +2,7 @@ FROM mdillon/postgis:11
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential gcc make cmake gdal-bin postgresql-server-dev-11 \
-    expat libexpat1-dev libboost-dev libboost-graph-dev libboost-program-options-dev libpqxx-dev \
+    libboost-dev libboost-graph-dev \
     wget ca-certificates
 
 RUN wget -O pgrouting-3.1.0.tar.gz https://github.com/pgRouting/pgrouting/archive/v3.1.0.tar.gz && \
@@ -14,12 +14,3 @@ RUN wget -O pgrouting-3.1.0.tar.gz https://github.com/pgRouting/pgrouting/archiv
     make && \
     make install && \
     cd / && rm -Rf pgrouting-3.1.0*
-
-RUN wget -O osm2pgrouting-2.3.6.tar.gz https://github.com/pgRouting/osm2pgrouting/archive/v2.3.6.tar.gz && \
-    tar xvfz osm2pgrouting-2.3.6.tar.gz && \
-    cd osm2pgrouting-2.3.6 && \
-    cmake -H. -Bbuild && \
-    cd build && \
-    make && \
-    make install && \
-    cd / && rm -Rf osm2pgrouting-2.3.6*

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -4,11 +4,13 @@ services:
   make:
     container_name: mellow-bike-map-make
     image: mellow-bike-map-make
-    build: ./db
+    build: .
     depends_on:
       postgres:
         condition: service_healthy
     volumes:
       - ./:/app
     working_dir: /app
+    environment:
+      DJANGO_SECRET_KEY: reallysupersecret
     entrypoint: make


### PR DESCRIPTION
## Overview

This PR splits `db/Dockerfile` into two Dockerfiles so that the Postgres, Make, and Django services can each have their own Dockerfile with the separate dependencies required of each service.

Closes #17.

## Testing instructions

* Make sure you don't have any new mapping data; if you do, save it to a fixture first by following the [`Exporting routes` section of the README](https://github.com/jeancochrane/mellow-bike-map#exporting-routes)
* Remove your development database with `docker-compose down --volumes`
* Follow the new instructions in the [`Developing` section of the README](https://github.com/jeancochrane/mellow-bike-map/tree/jfc/fix-import#developing) and make sure that the commands successfully build containers and import data