### PR TITLE
Display distance and time estimates for routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: python
 services:
   - docker
 install:
-  - docker-compose build
+  - docker-compose build app
 script:
-  - docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
+  - docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm --no-deps app
 deploy:
   provider: codedeploy
   access_key_id: AKIAXHI2VYRZ56DCFMU6

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ env:
   - DJANGO_SECRET_KEY=reallysupersecret
   - DJANGO_SETTINGS_MODULE=mbm.settings
 script:
-  - cd app
-  - ls -lah
-  - pytest tests
+  - cp -R tests app/tests
+  - cd app && pytest
 deploy:
   provider: codedeploy
   access_key_id: AKIAXHI2VYRZ56DCFMU6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ branches:
   only:
   - master
 language: python
+dist: bionic
 python:
-  - '3.6'
+  - '3.8'
 install:
   - sudo apt-get update && sudo apt-get install -y --no-install-recommends gdal-bin
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ env:
   - DJANGO_SECRET_KEY=reallysupersecret
   - DJANGO_SETTINGS_MODULE=mbm.settings
 script:
-  - cd app && pytest
+  - cd app
+  - ls tests
+  - pytest tests
 deploy:
   provider: codedeploy
   access_key_id: AKIAXHI2VYRZ56DCFMU6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,12 @@ branches:
   only:
   - master
 language: python
-python:
-- '3.6'
+services:
+  - docker
 install:
-- pip install --upgrade pip
-- pip install --upgrade -r app/requirements.txt
-addons:
-  postgresql: '11'
+  - docker-compose build
 script:
-- cd app && DJANGO_SECRET_KEY=reallysupersecret DJANGO_SETTINGS_MODULE=mbm.settings pytest
+  - docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 deploy:
   provider: codedeploy
   access_key_id: AKIAXHI2VYRZ56DCFMU6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - DJANGO_SETTINGS_MODULE=mbm.settings
 script:
   - cd app
-  - ls tests
+  - ls -lah
   - pytest tests
 deploy:
   provider: codedeploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 python:
   - '3.6'
 install:
-  - apt-get install -y --no-install-recommends gdal-bin
+  - sudo apt-get update && sudo apt-get install -y --no-install-recommends gdal-bin
   - pip install --upgrade pip
   - pip install --upgrade -r app/requirements.txt
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ install:
 addons:
   postgresql: '11'
 env:
-  - DJANGO_SECRET_KEY=reallysupersecret
-  - DJANGO_SETTINGS_MODULE=mbm.settings
+  - DJANGO_SECRET_KEY=reallysupersecret DJANGO_SETTINGS_MODULE=mbm.settings
 script:
   - cp -R tests app/tests
   - cd app && pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,19 @@ branches:
   only:
   - master
 language: python
-services:
-  - docker
+python:
+  - '3.6'
 install:
-  - docker-compose build
-  - docker-compose up -d postgres
+  - apt-get install -y --no-install-recommends gdal-bin
+  - pip install --upgrade pip
+  - pip install --upgrade -r app/requirements.txt
+addons:
+  postgresql: '11'
+env:
+  - DJANGO_SECRET_KEY=reallysupersecret
+  - DJANGO_SETTINGS_MODULE=mbm.settings
 script:
-  - docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
+  - cd app && pytest
 deploy:
   provider: codedeploy
   access_key_id: AKIAXHI2VYRZ56DCFMU6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
 - pip install --upgrade -r app/requirements.txt
 addons:
   postgresql: '11'
-script: echo "No tests -- skipping"
+script:
+- cd app && DJANGO_SECRET_KEY=reallysupersecret DJANGO_SETTINGS_MODULE=mbm.settings pytest
 deploy:
   provider: codedeploy
   access_key_id: AKIAXHI2VYRZ56DCFMU6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: python
 services:
   - docker
 install:
-  - docker-compose build app
+  - docker-compose build
+  - docker-compose up -d postgres
 script:
-  - docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm --no-deps app
+  - docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 deploy:
   provider: codedeploy
   access_key_id: AKIAXHI2VYRZ56DCFMU6

--- a/app/mbm/templates/mbm/index.html
+++ b/app/mbm/templates/mbm/index.html
@@ -20,6 +20,7 @@
           <input id="target" name="target" hidden="true"></input>
           <button id="submit" class="btn btn-primary btn-block mt-1">Search</button>
           <button id="reset-search" class="btn btn-secondary btn-block mb-2">Reset search</button>
+          <span id="route-estimate" class="text-muted"></span>
         </div>
         <button
           id="hide"
@@ -74,6 +75,18 @@
         case 'path': return '#e17fa8'
         default: return '#7ea4e1'
       }
+    }
+
+    const showRouteEstimate = (distance, time) => {
+      $('#route-estimate').html(`<strong>${time}</strong> (${distance})`)
+      $('#route-estimate').show()
+      $('#hide, #hide-legend').addClass('mt-1')
+    }
+
+    const hideRouteEstimate = () => {
+      $('#route-estimate').hide()
+      $('#route-estimate').html('')
+      $('#hide, #hide-legend').removeClass('mt-1')
     }
 
     const googleStyles = [
@@ -196,6 +209,7 @@
             // Lower opacity on non-route street colors
             allRoutesLayer.setStyle({opacity: 0.3})
             map.fitBounds(routeLayer.getBounds())
+            showRouteEstimate(data.route.properties.distance, data.route.properties.time)
           }).fail(function(jqxhr, textStatus, error) {
             const err = textStatus + ': ' + error
             alert('Request failed: ' + err)
@@ -212,6 +226,7 @@
         if (markers['target']) { map.removeLayer(markers['target']) }
         allRoutesLayer.setStyle({opacity: 0.6})
         $('#source, #source_text, #target, #target_text').val('')
+        hideRouteEstimate()
       })
 
       const isHidden = (elem) => { return $(elem).data('state') === 'hidden' }

--- a/app/mbm/views.py
+++ b/app/mbm/views.py
@@ -173,7 +173,7 @@ class Route(APIView):
         distance = f'{formatted_dist} {dist_unit_str}'
 
         # Assume 8mph as a naive guess of speed
-        mi_per_min = 8 / 60
+        mi_per_min = 10 / 60
         time_in_min = dist_in_mi / mi_per_min
         formatted_time = '<1' if time_in_min < 1 else str(round(time_in_min))
         time_unit_str = 'minute' if formatted_time in ['<1', '1'] else 'minutes'

--- a/app/mbm/views.py
+++ b/app/mbm/views.py
@@ -127,7 +127,7 @@ class Route(APIView):
                 JOIN chicago_ways AS way
                 ON path.edge = way.gid
                 LEFT JOIN (
-                    SELECT UNNEST(ways) AS osm_id, type
+                    SELECT DISTINCT(UNNEST(ways)) AS osm_id, type
                     FROM mbm_mellowroute
                 ) as mellow
                 USING(osm_id)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.4'
+
+services:
+  app:
+    volumes:
+      - ./tests:/app/tests
+    environment:
+      DJANGO_SECRET_KEY: reallysupersecret
+      DJANGO_SETTINGS_MODULE: mbm.settings
+    command: pytest -sxv

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,16 @@
+import pytest
+from mbm import views
+
+
+@pytest.mark.parametrize('dist_in_meters,expected', [
+    (100, ('0.1 miles', '<1 minute')),
+    (215, ('0.1 miles', '1 minute')),
+    (1000, ('0.6 miles', '5 minutes')),
+    (1609, ('1.0 miles', '7 minutes'))
+])
+def test_format_distance(dist_in_meters, expected):
+    route = views.Route()
+    distance, time = route.format_distance(dist_in_meters)
+    expected_dist, expected_time = expected
+    assert distance == expected_dist
+    assert time == expected_time

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,9 +4,9 @@ from mbm import views
 
 @pytest.mark.parametrize('dist_in_meters,expected', [
     (100, ('0.1 miles', '<1 minute')),
-    (215, ('0.1 miles', '1 minute')),
-    (1000, ('0.6 miles', '5 minutes')),
-    (1609, ('1.0 miles', '7 minutes'))
+    (300, ('0.2 miles', '1 minute')),
+    (1000, ('0.6 miles', '4 minutes')),
+    (1609, ('1.0 miles', '6 minutes'))
 ])
 def test_format_distance(dist_in_meters, expected):
     route = views.Route()


### PR DESCRIPTION
## Overview

Use the combined length of the route fragments in meters to display a distance and time estimate when a user searches for a route.

Closes #27.

## Demo

![2020-10-09 13 07 32](https://user-images.githubusercontent.com/14170650/95617140-9043c300-0a30-11eb-84bc-8634c106e768.gif)

## Testing instructions

- Ensure tests pass on CI
- If you don't already have a development environment set up, let me know and I'll get you a dump of the database and help you restore it
- Start the development server: `docker-compose up --build`
- Navigate to http://localhost:8000/
- Enter a route and confirm you see a distance and time estimate display in the search box
- Search for another route and confirm the distance and time estimate changes
- Hit "Reset search" and confirm that it clears the distance and time estimate
