### PR TITLE
Update postgis and postgres libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential gcc make cmake gdal-bin postgresql-server-dev-11 postgresql-11-postgis-2.5 \
+    build-essential gcc make cmake gdal-bin postgresql-server-dev-13 postgresql-13-postgis-3 \
     expat libexpat1-dev libboost-dev libboost-graph-dev libboost-program-options-dev libpqxx-dev \
     osmctools wget ca-certificates
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,7 +1,7 @@
 dj-database-url==0.5.0
 Django==3.1
 gunicorn==20.0.4
-psycopg2==2.8.5
+psycopg2-binary==2.8.5
 pytest-django==3.9.0
 pytest-mock==3.3.0
 sentry-sdk==0.16.5


### PR DESCRIPTION
When I tried to build the main python image and run make (`docker-compose -f docker-compose.yml -f docker-compose.db.yml build`), it failed because apt couldn't find `postgresql-server-dev-11` or `postgresql-11-postgis-2.5`. I think this is because the docker image is based on `python:3.8` and that has changed from being based on Debian 10 to 11. Presumably you'll see this error as well if you try to redeploy mbm or rebuild locally - can you confirm?

These updates seem to work alright for me, but if you'd rather, I can just pin the Dockerfile to a specific underlying debian release but I'm not sure which one works!