### PR TITLE
Restrict maps autocomplete suggestions to USA

### DIFF
--- a/app/mbm/templates/mbm/index.html
+++ b/app/mbm/templates/mbm/index.html
@@ -293,7 +293,9 @@
       const initAutocomplete = (textElementId, coordElementId, marker) => {
         // Create the autocomplete object
         let autocomplete = new google.maps.places.Autocomplete(
-          document.getElementById(textElementId)
+          document.getElementById(textElementId), {
+            componentRestrictions: { country: "us" },
+          }
         )
         // Avoid paying for data that you don't need by restricting the set of
         // place fields that are returned to just the address components.


### PR DESCRIPTION
This PR restricts autocomplete suggestions to only include US locations. This is in addition to the code which biases results to near your location, since that existing bias doesn't actually prevent international addresses from being suggested.

I was also considering changing the bounds to a static rect of Chicago instead of getting them from the user or at least defaulting to that. But TBH this change alone has already fixed most of the issue that I was experiencing so that may be unnecessary.

Here are two examples to illustrate:

Suggestions for "My Position"
![image](https://user-images.githubusercontent.com/473542/184431496-74508b34-0d99-4b4a-b4df-a83d547db433.png)

Suggestions for "is"
![image](https://user-images.githubusercontent.com/473542/184431891-a2a67021-0214-4b12-8a41-b699d0187f40.png)

And here's what those two look like after my change

No suggestions for "My position" (as it should be)
![image](https://user-images.githubusercontent.com/473542/184432092-6ce9150a-9567-460b-8dc4-9b6fa0bbd877.png)

Better results for "is"
![image](https://user-images.githubusercontent.com/473542/184432017-1618e3e4-fc97-46aa-8efe-fd1110ec4e73.png)

