### PR TITLE
Update user location as they move around

### DIFF
--- a/app/mbm/templates/mbm/index.html
+++ b/app/mbm/templates/mbm/index.html
@@ -290,6 +290,10 @@
         ['postal_code', 'short_name', '']
       ]
 
+      const zoomToLocation = (lat, lng) => {
+        map.setView([lat, lng], 14)
+      }
+
       const initAutocomplete = (textElementId, coordElementId, marker) => {
         // Create the autocomplete object
         let autocomplete = new google.maps.places.Autocomplete(
@@ -344,7 +348,7 @@
               markers['source'] = L.marker(
                 [geolocation['lat'], geolocation['lng']]
               ).bindPopup('My position').addTo(map)
-              map.setView([geolocation.lat, geolocation.lng], 14)
+              zoomToLocation(geolocation.lat, geolocation.lng)
               hasZoomedtoUser = true
             }
             const circle = new google.maps.Circle({
@@ -354,6 +358,33 @@
             autocomplete.setBounds(circle.getBounds())
           })
         }
+      }
+
+      // Moves "source" marker to a new location, updates the source input that
+      // stores the location, and zooms to the new location
+      const updateSourceLocation = position => {
+        markers['source'].setLatLng({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude
+        })
+        document.getElementById('source').value = `${position.coords.latitude},${position.coords.longitude}`
+        zoomToLocation(position.coords.latitude, position.coords.longitude)
+      }
+
+      // Continually update the "source" marker with the user's location if th
+      if (navigator.geolocation) {
+        navigator.geolocation.watchPosition(position => {
+          if (!markers['source']) {
+            return
+          }
+          // Only update the source marker if the user is using their current location
+          // as the source location
+          if (document.getElementById('source_text').value != 'My position') {
+            return
+          }
+          updateSourceLocation(position)
+          console.log(`Updated position to (${position.coords.latitude},${position.coords.longitude})`)
+        })
       }
 
       let hasZoomedToUser = false


### PR DESCRIPTION
Rough draft for #35

This seems to work pretty well for me testing in Chrome (open devtools, cmd+shift+p -> "Show Sensors", set location to "Other" and change). I tested that it:
	- Updates the map marker as your location changes
	- Doesn't update the map marker if you're not using your current location as the starting point
	- Uses the new location if you click search again

Before merging, I'd like to remove some of the duplication that this creates with the `initAutocomplete` method and make some of these constants more explicit (the zoom level, the "My position" text). This also introduces a bunch of unnecessary `getElementById` calls which I'll fix. I'd also like to refactor so we store the current location in JS rather than writing it to an `<input>` element, although that's a little more involved. Let me know if those sound like okay changes!

I'm also wondering if we need a more explicit way to set the source location to "My position" now that we're actually tracking it. AFAICT the only way to do that right now is by reloading the page (although a quirk of my implementation is that you can now type "My position" into the autocomplete bar and it will then follow you). Perhaps a button next to the input? I'd like to discuss what that interface should look like before I move forward!