### PR TITLE
Disable user locations while we figure out iOS bugs

### DIFF
--- a/app/mbm/static/js/app.js
+++ b/app/mbm/static/js/app.js
@@ -1,7 +1,6 @@
 import UserLocations from './userlocations.js'
 import autocomplete from './autocomplete.js'
 import Geolocation from './geolocation.js'
-import { getUserPreferences, saveUserPreferences } from './storage.js'
 // The App class holds top level state and map related methods that other modules
 // need to call, for example to update the position of markers.
 export default class App {
@@ -68,27 +67,6 @@ export default class App {
     })
 
     this.createLegend().addTo(this.map)
-
-    // Allow users to name and save their own locations by double clicking on the map
-    this.userLocationsCheckbox = document.getElementById('enable-user-locations')
-    this.handleLocationsCheckboxChange = (event) => {
-      this.preferences.userLocationsEnabled = event.target.checked
-      saveUserPreferences(this.preferences)
-
-      if (event.target.checked && !this.userLocations) {
-        this.userLocations = new UserLocations(this)
-      } else {
-        this.userLocations.unmount()
-        this.userLocations = null
-      }
-    }
-    this.userLocationsCheckbox.addEventListener('change', this.handleLocationsCheckboxChange)
-
-    this.preferences = getUserPreferences()
-    if (this.preferences.userLocationsEnabled) {
-      this.userLocationsCheckbox.checked = true
-      this.userLocationsCheckbox.dispatchEvent(new Event('change'))
-    }
 
     // Load the routes layer from the backend
     this.loadAllRoutes()

--- a/app/mbm/templates/mbm/index.html
+++ b/app/mbm/templates/mbm/index.html
@@ -39,18 +39,6 @@
                 <i class="fa fa-fw fa-info-circle text-muted"></i>
               </i>
             </div>
-            <div>
-              <input type="checkbox" id="enable-user-locations" name="enable-user-locations" />
-              <label for="enable-user-locations" style="padding-left: 5px">Enable saved locations</label>
-              <i
-                data-toggle="tooltip"
-                data-placement="top"
-                title="When this is checked, double-clicking or double-tapping on the map will no longer zoom in and will instead open a dialog to save a location at that point."
-                style="cursor: pointer"
-              >
-                <i class="fa fa-fw fa-info-circle text-muted"></i>
-              </i>
-            </div>
           </div>
           <span id="route-estimate" class="text-muted"></span>
         </form>


### PR DESCRIPTION
Rather than comment out the user location code, this PR simply removes the checkbox from `index.html` and strips out the section of `App.start()` that previously initialized saved locations and preferences. Once we fix the iOS bugs we can revert the merge commit for this PR to re-enable the feature.