### PR TITLE
update postgis docker image

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,16 +1,16 @@
-FROM mdillon/postgis:11
+FROM postgis/postgis:13-3.3
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential gcc make cmake gdal-bin postgresql-server-dev-11 \
+    build-essential gcc make cmake gdal-bin postgresql-server-dev-13 \
     libboost-dev libboost-graph-dev \
     wget ca-certificates
 
-RUN wget -O pgrouting-3.1.0.tar.gz https://github.com/pgRouting/pgrouting/archive/v3.1.0.tar.gz && \
-    tar xvfz pgrouting-3.1.0.tar.gz && \
-    cd pgrouting-3.1.0 && \
+RUN wget -O pgrouting-3.1.4.tar.gz https://github.com/pgRouting/pgrouting/archive/v3.1.4.tar.gz && \
+    tar xvfz pgrouting-3.1.4.tar.gz && \
+    cd pgrouting-3.1.4 && \
     mkdir build && \
     cd build && \
     cmake .. && \
     make && \
     make install && \
-    cd / && rm -Rf pgrouting-3.1.0*
+    cd / && rm -Rf pgrouting-3.1.4*


### PR DESCRIPTION
On a fresh install of the repo, I was unable to build the project. The build would fail during the step

`=> ERROR [postgres 2/3] RUN apt-get update && apt-get install -y --no-install-recommends`

Digging deeper, it would appear the build was failing on apt calls update and install with 404 responses. I believe that is because `db/Dockerfile` is built on this no-longer maintained image: [mdillon/postgis](https://hub.docker.com/r/mdillon/postgis). I think that image is built on [Debian 9 (stretch) which has surpassed its LTS timeframe](https://www.debian.org/releases/stretch/).

Fortunately, it appears there is now an official and [maintained postgis image](https://registry.hub.docker.com/r/postgis/postgis). Changing the first line of `db/Dockerfile` to `FROM postgis/postgis:13-3.3` resolved my build issues. 

You could go ahead and skip to postgres 15 with this update, to jump to the latest stable version, but the other dockerfiles seemed to be on 13, which is why I chose that