### PR TITLE
Update Node from 12.x to 22.x

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8
 
 # Add the NodeSource PPA
 # (see: https://github.com/nodesource/distributions/blob/master/README.md)
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs gdal-bin
 


### PR DESCRIPTION
Node 12 is EOLed and didn't install when I ran the Dockerfile. The `npm install` line failed with a "npm not found" error. Updating to active LTS version 22 works.