### PR TITLE
Filter to only necessary OSM data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ db/import/chicago.table: db/raw/chicago-filtered.osm
 	touch $@
 
 
-db/raw/chicago-filtered.osm: db/raw/chicago-simplified.osm
+db/raw/chicago-filtered.osm: db/raw/chicago.osm
 	osmfilter $< \
 		--keep="highway= bicycle= cycleway= route=bicycle" \
 		--drop="building= amenity= shop= tourism= leisure= landuse= natural= power= waterway=" \

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,12 @@ db/import/chicago.table: db/raw/chicago-filtered.osm
 	touch $@
 
 
-db/raw/chicago-filtered.osm: db/raw/chicago.osm
-	osmconvert $< --drop-author --drop-version --out-osm -o="$@"
+db/raw/chicago-filtered.osm: db/raw/chicago-simplified.osm
+	osmfilter $< \
+		--keep="highway= bicycle= cycleway= route=bicycle" \
+		--drop="building= amenity= shop= tourism= leisure= landuse= natural= power= waterway=" \
+		--drop-author --drop-version \
+		-o=$@
 
 
 db/raw/chicago.osm:


### PR DESCRIPTION
I OOMed when building even giving Docker as much memory as possible, so I was wondering whether we could reduce the amount of OSM data we're using and make it easier to build. 

Since we only need OSM for calculating routes, filtering to the tags `"highway= bicycle= cycleway= route=bicycle"` seemed viable, didn't OOM for me, and didn't present an issue for me briefly manually testing the app after building.

Hope I didn't miss a necessary tag?

Marking as draft due to not having thoroughly researched these changes.