### PR TITLE
Bound Google Maps search to Chicagoland

### DIFF
--- a/app/mbm/static/js/autocomplete.js
+++ b/app/mbm/static/js/autocomplete.js
@@ -12,7 +12,7 @@ const initAutocomplete = (inputElement, markerName, app) => {
   // Define bounds for Chicagoland
   const chicagoBounds = new google.maps.LatLngBounds(
     new google.maps.LatLng(41.45, -88.3),
-    new google.maps.LatLng(42.2, -87.5)
+    new google.maps.LatLng(42.2, -87.3)
   )
 
   // Create the autocomplete object with Chicagoland bounds and strict bounds enforcement


### PR DESCRIPTION
Results from Ohio and Texas show up in Google Maps autocomplete. Bound Google Maps search to this polygon (eastern boundary expanded per @jeancochrane's suggestion):

<img width="627" height="560" alt="image" src="https://github.com/user-attachments/assets/206ec2bd-f1d5-4de1-ab62-ae385db6d530" />

For now I've left alone the other code (and relevant TODO comment) related to geolocation and autocomplete, but LMK if you have thoughts on those things.