### PR TITLE
Fix map XY dimension overflow issues

### DIFF
--- a/app/mbm/static/js/app.js
+++ b/app/mbm/static/js/app.js
@@ -98,6 +98,12 @@ export default class App {
       if (this.isMobileScreen) { offsetTop += $('#controls-container')[0].offsetHeight }
       var mapHeight = windowHeight - offsetTop
       $('#map').css('height', mapHeight)
+      // Invalidate the map size so that Leaflet will re-check the container's
+      // dimensions and propagate them to all layers, including the Google
+      // layer integration. This is important because otherwise those layers
+      // may not pick up on window size changes, leading to areas of the map
+      // appearing to fail to load
+      this.map.invalidateSize()
     }).resize()
 
     // Recalculate map size when controls are toggled

--- a/app/mbm/templates/mbm/index.html
+++ b/app/mbm/templates/mbm/index.html
@@ -10,67 +10,70 @@
 {% endblock %}
 
 {% block body %}
-  <div class="row">
-    <div id="controls-container" class="col-12 col-md-3">
-      <div class="container-fluid m-auto form-group">
-        <form id="input-elements" class="hideable collapse multi-collapse">
-          <div class="form-group">
-            <label for="source" class="sr-only">Start address</label>
-            <input id="source" class="form-control my-2" name="source" placeholder="Start address"></input>
-          </div>
-          <div class="form-group">
-            <label for="target" class="sr-only">End address</label>
-            <input id="target" class="form-control my-2" name="target" placeholder="End address"></input>
-          </div>
-          <div class="form-group">
-            <button id="submit" type="submit" class="btn btn-primary btn-block mt-1">Search</button>
-            <button id="reset-search" type="reset" class="btn btn-secondary btn-block mb-2">Reset search</button>
-          </div>
-          <div class="form-group">
-            <div>
-              <input type="checkbox" id="enable-v2" name="enable-v2" />
-              <label for="enable-v2" style="padding-left: 5px">Use v2 routing</label>
-              <i
-                data-toggle="tooltip"
-                data-placement="top"
-                title="V2 routing uses a new experimental algorithm that considers all residential streets to be mellow streets."
-                style="cursor: pointer"
-              >
-                <i class="fa fa-fw fa-info-circle text-muted"></i>
-              </i>
+  <!-- Hack to enable full-bleed map, since containers add margins by default -->
+  <div style="overflow-x: hidden">
+    <div class="row">
+      <div id="controls-container" class="col-12 col-md-3">
+        <div class="container-fluid m-auto form-group">
+          <form id="input-elements" class="hideable collapse multi-collapse">
+            <div class="form-group">
+              <label for="source" class="sr-only">Start address</label>
+              <input id="source" class="form-control my-2" name="source" placeholder="Start address"></input>
             </div>
-            <div>
-              <input type="checkbox" id="enable-user-locations" name="enable-user-locations" />
-              <label for="enable-user-locations" style="padding-left: 5px">Enable saved locations</label>
-              <i
-                data-toggle="tooltip"
-                data-placement="top"
-                title="When this is checked, double-clicking or double-tapping on the map will no longer zoom in and will instead open a dialog to save a location at that point."
-                style="cursor: pointer"
-              >
-                <i class="fa fa-fw fa-info-circle text-muted"></i>
-              </i>
+            <div class="form-group">
+              <label for="target" class="sr-only">End address</label>
+              <input id="target" class="form-control my-2" name="target" placeholder="End address"></input>
             </div>
-          </div>
-          <span id="route-estimate" class="text-muted"></span>
-        </form>
-        <button
-          id="hide"
-          class="btn btn-outline-secondary mb-2 btn-block"
-          type="button"
-          data-toggle="collapse"
-          href=".hideable"
-          role="button"
-          aria-expanded="true"
-          aria-controls="input-elements navbar-tagline"
-          data-state="hidden"
-        >
-          &or; Search for a route
-        </button>
+            <div class="form-group">
+              <button id="submit" type="submit" class="btn btn-primary btn-block mt-1">Search</button>
+              <button id="reset-search" type="reset" class="btn btn-secondary btn-block mb-2">Reset search</button>
+            </div>
+            <div class="form-group">
+              <div>
+                <input type="checkbox" id="enable-v2" name="enable-v2" />
+                <label for="enable-v2" style="padding-left: 5px">Use v2 routing</label>
+                <i
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="V2 routing uses a new experimental algorithm that considers all residential streets to be mellow streets."
+                  style="cursor: pointer"
+                >
+                  <i class="fa fa-fw fa-info-circle text-muted"></i>
+                </i>
+              </div>
+              <div>
+                <input type="checkbox" id="enable-user-locations" name="enable-user-locations" />
+                <label for="enable-user-locations" style="padding-left: 5px">Enable saved locations</label>
+                <i
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="When this is checked, double-clicking or double-tapping on the map will no longer zoom in and will instead open a dialog to save a location at that point."
+                  style="cursor: pointer"
+                >
+                  <i class="fa fa-fw fa-info-circle text-muted"></i>
+                </i>
+              </div>
+            </div>
+            <span id="route-estimate" class="text-muted"></span>
+          </form>
+          <button
+            id="hide"
+            class="btn btn-outline-secondary mb-2 btn-block"
+            type="button"
+            data-toggle="collapse"
+            href=".hideable"
+            role="button"
+            aria-expanded="true"
+            aria-controls="input-elements navbar-tagline"
+            data-state="hidden"
+          >
+            &or; Search for a route
+          </button>
+        </div>
       </div>
-    </div>
-    <div class="col-12 col-md-9">
-      <div id="map"></div>
+      <div class="col-12 col-md-9">
+        <div id="map"></div>
+      </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This PR fixes two small bugs related to map dimensions that have been annoying me.

The first bug is related to the X dimension of the map: There's a thin vertical buffer just to the right of the map, which only appears if you scroll your page to the right. This is in contrast to the expected behavior, which is that the map will be full-bleed.

<img width="985" height="459" alt="Screenshot 2026-04-21 at 11 04 57 PM" src="https://github.com/user-attachments/assets/ac2647c3-373b-41cb-8e1b-ac9fe80fede1" />

The second bug is related to the Y dimension of the map: There's a thin horizontal buffer just below the map, which sometimes renders as a grey bar. This only seems to affect certain screen sizes, and only on page load; if you resize the screen, the bar goes away.

<img width="1552" height="987" alt="Screenshot 2026-04-21 at 11 08 34 PM" src="https://github.com/user-attachments/assets/3d4e6d1e-7f83-496c-9b3e-d05f482452da" />

This PR fixes both of these issues so that the map is full-bleed with no buffer on both the right and the bottom side.