### PR TITLE
Small tweaks to Sentry setup to fix deploys

### DIFF
--- a/app/mbm/settings.py
+++ b/app/mbm/settings.py
@@ -32,19 +32,21 @@ allowed_hosts = os.getenv('DJANGO_ALLOWED_HOSTS', [])
 ALLOWED_HOSTS = allowed_hosts.split(',') if allowed_hosts else []
 
 # Read the deployment id from our templated module if we're not in dev
+ENVIRONMENT = os.getenv('ENVIRONMENT')
 try:
     from .deployment import DEPLOYMENT_ID
 except ImportError as e:
-    if (os.getenv('ENVIRONMENT') in ('dev', 'test')):
+    if (ENVIRONMENT in ('dev', 'test')):
         DEPLOYMENT_ID = ''
     else:
         raise RuntimeError("Bad deployment") from e
+SENTRY_RELEASE = f"mbm-{ENVIRONMENT}@{DEPLOYMENT_ID}"
 
 # Configure Sentry for error logging
 ENABLE_SENTRY = True if os.getenv('SENTRY_DSN') else False
 if ENABLE_SENTRY:
     sentry_sdk.init(
-        release=DEPLOYMENT_ID,
+        release=SENTRY_RELEASE,
         dsn=os.environ['SENTRY_DSN'],
         before_send=before_send,
         integrations=[DjangoIntegration()],

--- a/app/mbm/views.py
+++ b/app/mbm/views.py
@@ -583,7 +583,7 @@ def server_error(request, template_name='mbm/500.html'):
     return render(request, template_name, status=500)
 
 
-def pong():
+def pong(request):
     from settings import DEPLOYMENT_ID
     return HttpResponse(DEPLOYMENT_ID)
 

--- a/app/mbm/views.py
+++ b/app/mbm/views.py
@@ -584,7 +584,7 @@ def server_error(request, template_name='mbm/500.html'):
 
 
 def pong(request):
-    from settings import DEPLOYMENT_ID
+    from mbm.settings import DEPLOYMENT_ID
     return HttpResponse(DEPLOYMENT_ID)
 
 

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -42,6 +42,11 @@ psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'mbm'" | grep -q
 # OPTIONAL Create any extensions within your database that your project needs.
 psql -U postgres -d mbm -f $PROJECT_DIR/db/create-extensions.sql
 
+# Write out the deployment ID to a Python module that can get imported by the
+# app. This needs to happen before the app starts up, including any management
+# commands, since the settings file expects it to exist in the prod environment
+echo "DEPLOYMENT_ID='$DEPLOYMENT_ID'" > $PROJECT_DIR/app/mbm/deployment.py
+
 # OPTIONAL Run migrations and other management commands that should be run with
 # every deployment
 export DJANGO_SECRET_KEY=temporarykey DATABASE_URL=postgres:///mbm DJANGO_DEBUG=False
@@ -72,7 +77,3 @@ fi
 # script.
 $VENV_DIR/bin/pip install "Jinja2>=2.10,<3.2"
 $VENV_DIR/bin/python $PROJECT_DIR/scripts/render_configs.py $DEPLOYMENT_ID $DEPLOYMENT_GROUP_NAME $DOMAIN $APP_NAME
-
-# Write out the deployment ID to a Python module that can get imported by the
-# app and returned by the /pong/ route (see above).
-echo "DEPLOYMENT_ID='$DEPLOYMENT_ID'" > $PROJECT_DIR/app/mbm/deployment.py


### PR DESCRIPTION
#104 brought in some changes to enable logging and alerting via Sentry. I forgot to test a deployment of that PR before approving and merging it, so it introduced a couple bugs to the deploy pipeline. This PR fixes those bugs, including:

1. **Generates the `mbm.deployment` module before running any management commands**: As of #104, the prod app now relies on the existence of a module `mbm.deployment` in order to send the deployment ID with every Sentry request. This module must exist before the app starts up in any prod environment, including the management commands that we run during deployment. The `scripts/before_install.sh` script currently writes `deployment.py` as its final step, but since it runs management commands before that step, all management commands will error out on startup, thereby causing deploys to fail:

```
[stderr]    main()
[stderr]  File "/home/mbm/mellow-bike-map-d-HBLA1VGEI/app/manage.py", line 17, in main
[stderr]    execute_from_command_line(sys.argv)
[stderr]  File "/home/mbm/.virtualenvs/mellow-bike-map-d-HBLA1VGEI/lib/python3.8/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
[stderr]    utility.execute()
[stderr]  File "/home/mbm/.virtualenvs/mellow-bike-map-d-HBLA1VGEI/lib/python3.8/site-packages/django/core/management/__init__.py", line 345, in execute
[stderr]    settings.INSTALLED_APPS
[stderr]  File "/home/mbm/.virtualenvs/mellow-bike-map-d-HBLA1VGEI/lib/python3.8/site-packages/django/conf/__init__.py", line 83, in __getattr__
[stderr]    self._setup(name)
[stderr]  File "/home/mbm/.virtualenvs/mellow-bike-map-d-HBLA1VGEI/lib/python3.8/site-packages/django/conf/__init__.py", line 70, in _setup
[stderr]    self._wrapped = Settings(settings_module)
[stderr]  File "/home/mbm/.virtualenvs/mellow-bike-map-d-HBLA1VGEI/lib/python3.8/site-packages/django/conf/__init__.py", line 177, in __init__
[stderr]    mod = importlib.import_module(self.SETTINGS_MODULE)
[stderr]  File "/home/mbm/.pyenv/versions/3.8.20/lib/python3.8/importlib/__init__.py", line 127, in import_module
[stderr]    return _bootstrap._gcd_import(name[level:], package, level)
[stderr]  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
[stderr]  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
[stderr]  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
[stderr]  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
[stderr]  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
[stderr]  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
[stderr]  File "/home/mbm/mellow-bike-map-d-HBLA1VGEI/app/mbm/settings.py", line 41, in <module>
[stderr]    raise RuntimeError("Bad deployment") from e
[stderr]RuntimeError: Bad deployment
```
2. **Sets the required `mbm.settings.SENTRY_RELEASE` constant**. The frontend code in #104 expects that a `sentry_release` variable be available to the templating engine. That PR created a `sentry_config` context processor to inject `SENTRY_RELEASE` into the template, but it neglected to actually define `SENTRY_RELEASE`. This PR defines that constant as a string following the pattern `"mbm-{ENVIRONMENT}@{DEPLOYMENT_ID}"`.
3. **Uses the absolute import path `mbm.settings` when importing the settings file into the `pong()` view function**. Prior to #104 this function would import `DEPLOYMENT_ID` directly from the `mbm.deployment` module, using a relative import path (`.deployment`) to accomplish that import. We changed that import to use an absolute import path when we moved the definition of `DEPLOYMENT_ID` to the settings file in #104, but we neglected to use the correct absolute path for the settings file when importing it into the `pong()` view function.

I tested these changes by deploying them to staging and confirming that the deployment worked.